### PR TITLE
Add additional WebSocket proxy information for Apache 2

### DIFF
--- a/docs/info/reverse-proxy.md
+++ b/docs/info/reverse-proxy.md
@@ -159,6 +159,7 @@ To run Apache with a reverse proxy setup, you'll need to activate certain module
     a2enmod proxy_balancer
     a2enmod proxy_connect
     a2enmod proxy_html
+    a2enmod proxy_wstunnel
 ```
 
 In your Virtualhost configuration file you'll need to add a few things.  
@@ -176,11 +177,11 @@ If you want to run ombi.example.com instead of site.example.com/ombi, then repla
 ### Apache2 Subdirectory
 
 ```conf
-    <Location /ombi>
+<Location /ombi>
     Allow from 0.0.0.0 
     ProxyPass "http://ip.of.ombi.host:5000/ombi" connectiontimeout=5 timeout=30 keepalive=on 
     ProxyPassReverse "http://ip.of.ombi.host:5000/ombi" 
-    </Location>
+</Location>
 ```
 
 ### Apache2 Subdomain
@@ -190,7 +191,17 @@ If you want to run ombi.example.com instead of site.example.com/ombi, then repla
     ProxyPassReverse /ombi http://ip.of.ombi.host:5000/ombi
 ```
 
-Once all your changes are done, you'll need to run `service apache2 restart` to make the changes go live.
+### Proxying WebSocket requests
+
+WebSocket requests need to specifically handled when using a reverse proxy. The configuration below needs to be applied in addition to any ProxyPass/ProxyReverse configuration. This will ensure WebSocket requests are handled correctly through the reverse proxy.
+
+```conf
+RewriteEngine On
+RewriteCond %{HTTP:Upgrade} =websocket [NC]
+RewriteRule /ombi/(.*) ws://ip.of.ombi.host:5000/ombi/$1 [P,L]
+```
+
+Once all your changes are done, you'll need to run `service apache2 restart` to make the changes go live. For Linux distributions using `systemd`, you can use `systemctl restart apache2`.
 
 ***
 


### PR DESCRIPTION
WebSocket requests will fail under a reverse proxy unless they are specifically handled through proxy_wstunnel and rewrite rules. This adds documentation on how to implement rules for WebSocket requests. Any WebSocket requests under the /ombi path should be correctly handled with these additional RewriteEngine rules.

This has been tested on Apache 2.4.41 with Ombi 4.9.0. Without this specific handling, console errors will be logged related to WebSocket errors for `/ombi/hubs/notification`